### PR TITLE
chore: bump dep vers & update jei maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ subprojects {
     repositories {
         mavenCentral()
         maven { url = "https://maven.shedaniel.me/" } // Cloth Config, REI
-        maven { url = "https://dvs1.progwml6.com/files/maven/" } // JEI
+        maven { url = "https://maven.blamejared.com/" } // JEI
         maven { url = "https://maven.parchmentmc.org" } // Parchment mappings
         maven { url = "https://maven.quiltmc.org/repository/release" } // Quilt Mappings
         maven { // Flywheel

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,26 +10,26 @@ enabled_platforms = fabric,forge
 
 # Mappings
 # https://lambdaurora.dev/tools/import_quilt.html
-qm_version = 21
+qm_version = 22
 # https://parchmentmc.org/docs/getting-started
 parchment_version = 2022.11.27
 
 # Fabric
 # https://fabricmc.net/develop/
-fabric_loader_version = 0.14.11
-fabric_api_version = 0.67.0+1.19.2
+fabric_loader_version = 0.14.21
+fabric_api_version = 0.76.0+1.19.2
 
 # Forge
 # https://files.minecraftforge.net/net/minecraftforge/forge/
-forge_version = 43.2.0
+forge_version = 43.2.14
 
 # Create - Fabric
 # https://modrinth.com/mod/create-fabric/versions
-create_fabric_version = 0.5.0.i-946+1.19.2
+create_fabric_version = 0.5.1-b-build.1089+mc1.19.2
 
 # Create - Forge
 # https://github.com/Creators-of-Create/Create/wiki/Depending-on-Create
-create_forge_version = 0.5.0.i-23
+create_forge_version = 0.5.1.b-30
 registrate_forge_version = MC1.19-1.1.5
 flywheel_forge_minecraft_version = 1.19.2
 flywheel_forge_version = 0.6.8.a-14
@@ -38,14 +38,14 @@ flywheel_forge_version = 0.6.8.a-14
 # Create Fabric supports all 3 recipe viewers: JEI, REI, and EMI. This decides which is enabled at runtime.
 # set to disabled to have none of them.
 fabric_recipe_viewer = unspecified
-# JEI - https://www.curseforge.com/minecraft/mc-mods/jei/files/all
-jei_version = 11.2.0.254
-# REI - https://modrinth.com/mod/roughly-enough-items/versions
-rei_version = 9.1.580
+# JEI - https://www.curseforge.com/minecraft/mc-mods/jei/files
+jei_version = 11.6.0.1016
+# REI - https://modrinth.com/mod/rei/versions
+rei_version = 9.1.619
 # EMI - https://modrinth.com/mod/emi/versions
-emi_version = 0.6.1+1.19.2
+emi_version = 1.0.5+1.19.2
 
 # Mod Menu - https://modrinth.com/mod/modmenu/versions
-modmenu_version = 4.1.2
+modmenu_version = 4.2.0-beta.2
 # LazyDFU - https://modrinth.com/mod/lazydfu/versions
 lazydfu_version = 0.1.3


### PR DESCRIPTION
Small little stuff wont be doing the same for 1.18 since its basically done now that create has dropped 1.18 support