### PR TITLE
Create 6.0 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,9 @@ subprojects {
 
         // mavens used on both forge and fabric
         maven { url = "https://maven.blamejared.com/" } // JEI
-        maven { url = "https://maven.tterrag.com/" } // Flywheel on both, Create and Registrate on forge
+        maven { url = "https://maven.createmod.net" } // Create, Ponder, Flywheel
+        maven { url = "https://maven.tterrag.com" } // Registrate
+        maven { url = "https://raw.githubusercontent.com/Fuzss/modresources/main/maven/" } // ForgeConfigAPIPort
     }
 
     dependencies {

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -34,15 +34,19 @@ dependencies {
     shadowCommon(project(path: ":common", configuration: "transformProductionForge")) { transitive = false }
 
     // Create and its dependencies
-    modImplementation("com.simibubi.create:create-$minecraft_version:$create_forge_version:slim") { transitive = false }
-    modImplementation("com.tterrag.registrate:Registrate:$registrate_forge_version")
-    modImplementation("com.jozufozu.flywheel:flywheel-forge-$flywheel_forge_minecraft_version:$flywheel_forge_version")
+    modImplementation("com.simibubi.create:create-${minecraft_version}:${create_forge_version}:slim") { transitive = false }
+    modImplementation("net.createmod.ponder:Ponder-Forge-${minecraft_version}:${ponder_version}")
+    modCompileOnly("dev.engine-room.flywheel:flywheel-forge-api-${minecraft_version}:${flywheel_forge_version}")
+    modRuntimeOnly("dev.engine-room.flywheel:flywheel-forge-${minecraft_version}:${flywheel_forge_version}")
+    modImplementation("com.tterrag.registrate:Registrate:${registrate_forge_version}")
 
     // Development QOL
     modLocalRuntime("mezz.jei:jei-$minecraft_version-forge:$jei_version") { transitive = false }
 
     // if you would like to add integration with JEI, uncomment this line.
 //    modCompileOnly("mezz.jei:jei-$minecraft_version:$jei_version:api")
+    compileOnly(annotationProcessor("io.github.llamalad7:mixinextras-common:0.4.1"))
+    implementation("io.github.llamalad7:mixinextras-forge:0.4.1")
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ jei_version = 15.20.0.106
 # REI - https://modrinth.com/mod/rei/versions
 rei_version = 12.1.785
 # EMI - https://modrinth.com/mod/emi/versions
-emi_version = 1.1.20
+emi_version = 1.1.20+1.20.1
 
 # Mod Menu - https://modrinth.com/mod/modmenu/versions
 modmenu_version = 7.2.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,34 +14,35 @@ parchment_version = 2023.09.03
 
 # Fabric
 # https://fabricmc.net/develop/
-fabric_loader_version = 0.16.9
-fabric_api_version = 0.92.0+1.20.1
+fabric_loader_version = 0.16.10
+fabric_api_version = 0.92.3+1.20.1
 
 # Forge
 # https://files.minecraftforge.net/net/minecraftforge/forge/
-forge_version = 47.1.43
+forge_version = 47.4.0
 
 # Create - Fabric
 # https://modrinth.com/mod/create-fabric/versions
-create_fabric_version = 0.5.1-j-build.1631+mc1.20.1
+create_fabric_version = 6.0.0.0+mc1.20.1-build.1648
 
 # Create - Forge
 # https://github.com/Creators-of-Create/Create/wiki/Depending-on-Create
-create_forge_version = 0.5.1.j-55
+create_forge_version = 6.0.2-52
 registrate_forge_version = MC1.20-1.3.3
 flywheel_forge_minecraft_version = 1.20.1
-flywheel_forge_version = 0.6.11-13
+flywheel_forge_version = 1.0.1
+ponder_version = 1.0.51
 
 # Development QOL
 # Create Fabric supports all 3 recipe viewers: JEI, REI, and EMI. This decides which is enabled at runtime.
 # set to disabled to have none of them.
 fabric_recipe_viewer = unspecified
 # JEI - https://www.curseforge.com/minecraft/mc-mods/jei/files/all
-jei_version = 15.2.0.22
+jei_version = 15.20.0.106
 # REI - https://modrinth.com/mod/rei/versions
-rei_version = 12.0.626
+rei_version = 12.1.785
 # EMI - https://modrinth.com/mod/emi/versions
-emi_version = 1.1.18+1.20.1
+emi_version = 1.1.20
 
 # Mod Menu - https://modrinth.com/mod/modmenu/versions
-modmenu_version = 7.1.0
+modmenu_version = 7.2.2


### PR DESCRIPTION
Even though Create Fabric hasn't yet been ported, having a multiloader template available would allow for addons to get started on porting work, and at least allow multiloader addons to have support for Create 6.0 on Forge. 

This could also work as a separate branch, feel free to retarget as necessary.