### PR TITLE
Fix misspelling for 'rootProject.name'

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -11,4 +11,4 @@ include("common")
 include("fabric")
 include("forge")
 
-rootProject.name = "create-multiloader-addon-tempate"
+rootProject.name = "create-multiloader-addon-template"


### PR DESCRIPTION
very small PR that fixes the misspelling for 'rootProject.name'